### PR TITLE
feat: :sparkles: Adiciona rota e schema de recuperação de senha do us…

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -85,3 +85,55 @@ def get_me(db:Session = Depends(get_db), usuario = Depends(allowed_roles())):
 	"""Rota para obter informações do usuário autenticado"""
 	user = db.query(Usuario).filter(Usuario.id == usuario["id"]).first()
 	return user
+
+
+# Rota para solicitar redefinicao de senha.
+#recebe o email, verifica se existe e gera um token que sera enviado por email.
+@router.post("/recover", status_code=status.HTTP_200_OK)
+def recuperar_senha(
+    dados: Recuperacaodesenha, 
+    db: Session = Depends(get_db)
+):
+    user = db.query(Usuario).filter(Usuario.email == dados.email).first()
+
+    if user:
+        print(f"DEBUG: Simulação de envio de email para {user.email}")
+        pass
+    return {"msg": "Você receberá um link de recuperação via email."}
+
+
+# Rota POST: confirmar redefinicao de senha.
+# Recebe o token (vindo do e-mail) e a nova senha, valida e atualiza no banco.
+@router.post("/recover/confirm", status_code=status.HTTP_200_OK)
+def confirmar_recuperacao(
+    dados: Novasenha, 
+    db: Session = Depends(get_db)
+):  
+
+    # Busca usuário no banco
+    user = db.query(Usuario).filter(Usuario.email == email_usuario_simulado).first()
+    if not user:
+        raise HTTPException(status_code=404, detail="Usuário não encontrado")
+
+    # Cria nova hash de senha
+    senha_com_salt = create_salt(dados.nova_senha, user.email)
+    novo_hash = get_password_hash(senha_com_salt)
+
+    # 4. Atualizar e Salvar
+    user.senha_hash = novo_hash
+    db.commit()
+
+    return {"msg": "Senha alterada com sucesso!"}
+
+
+# Rota renova token de autentificacao sem a necessidade de fazer login novamente.
+@router.get("/refresh", response_model=TokenResponse)
+def refresh_token(
+    usuario_atual = Depends(allowed_roles()) 
+):
+    	novo_token = create_access_token(
+        user_id=usuario_atual["id"], 
+        email=usuario_atual["email"], 
+        role=usuario_atual["role"] # ou 'tipo_usuario' dependendo de como retorna
+    )
+	return {"access_token": novo_token}

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -58,8 +58,19 @@ class UsuarioLogin(BaseModel):
 
 class TokenResponse(BaseModel):
     access_token: str
+    refresh_token: Optional[str] = None 
     token_type: str = "bearer"
 
 
 class UsuarioAdminUpdate(BaseModel):
     tipo_usuario: TipoUser
+
+
+# Classe que chama o email
+class Recuperacaodesenha(BaseModel):
+    email: EmailType
+
+# Recebe o token para autenticar a solicitação e a nova senha
+class Novasenha(BaseModel):
+    token: str = Field(..., description="Token de recuperação recebido por e-mail")
+    nova_senha: SenhaType


### PR DESCRIPTION
# 🛠️ Pull Request — Implementação do fluxo de recuperação de senha

Este PR adiciona o fluxo inicial de **recuperação e redefinição de senha** ao sistema de autenticação.  
Foram criadas novas rotas para:

1. **Solicitar recuperação de senha** (`POST /recover`)
2. **Confirmar a recuperação e definir nova senha** (`POST /recover/confirm`)
3. **Renovar token de autenticação** (`GET /refresh`)

Também foram adicionados/ajustados os *schemas* necessários para validar as requisições.

---

## ✔️ O que foi feito

### 🔹 1. Rota `POST /recover`
- Recebe o e-mail do usuário.
- Verifica sua existência no banco.
- Gera um token de recuperação (no momento, simulação).
- Exibe log de envio de e-mail (simulado).

### 🔹 2. Rota `POST /recover/confirm`
- Recebe o **token de recuperação** e a **nova senha**.
- Valida o usuário (por enquanto usando um e-mail simulado).
- Gera novo hash de senha com salt.
- Persiste a atualização no banco.

### 🔹 3. Rota `GET /refresh`
- Gera um novo token JWT sem necessidade de login.
- Retorna o novo token para o cliente.

### 🔹 4. Schemas adicionados
- `Recuperacaodesenha`: valida e-mail.
- `Novasenha`: valida token de recuperação e nova senha.

---

## 🧩 Pontos importantes

- A integração com um serviço real de e-mail ainda não foi implementada (hoje apenas simula no log).
- `confirmar_recuperacao` ainda usa `email_usuario_simulado` (necessário ajustar posteriormente).
- O token de recuperação ainda não é validado – deve ser implementada lógica real de geração, armazenamento e validação.

---

## 🚀 Próximos passos sugeridos

- Implementar **geração real do token** (JWT, UUID ou hash aleatório).
- Criar tabela ou campo para armazenar token + expiração.
- Implementar serviço de envio de e-mail (SendGrid, Amazon SES, SMTP etc.).
- Trocar o placeholder `email_usuario_simulado` por validação real via token.
