### PR TITLE
Padronização de Respostas de Erro da API

### DIFF
--- a/backend/app/core/error_handlers.py
+++ b/backend/app/core/error_handlers.py
@@ -1,0 +1,35 @@
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from app.schemas.error import ErrorResponse
+from app.core.exceptions import AppException
+
+async def app_exception_handler(request: Request, exc: AppException):
+    payload = ErrorResponse(
+        data=exc.data,
+        message=exc.message,
+    )
+    return JSONResponse(status_code=exc.status_code, content=payload.model_dump())
+
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    payload = ErrorResponse(
+        data=exc.errors(),
+        message="Erro de validação na requisição.",
+    )
+    return JSONResponse(status_code=422, content=payload.model_dump())
+
+async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+    payload = ErrorResponse(
+        data=None,
+        message=str(exc.detail) if exc.detail else "Erro na requisição.",
+    )
+    return JSONResponse(status_code=exc.status_code, content=payload.model_dump())
+
+async def unhandled_exception_handler(request: Request, exc: Exception):
+    payload = ErrorResponse(
+        data=None,
+        message="Erro interno inesperado.",
+    )
+    return JSONResponse(status_code=500, content=payload.model_dump())

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+class AppException(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        data: Any = None,
+        status_code: int = 400,
+    ):
+        super().__init__(message)
+        self.message = message
+        self.data = data
+        self.status_code = status_code

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,14 @@
 from fastapi import FastAPI
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from app.core.exceptions import AppException
+from app.core.error_handlers import (
+    app_exception_handler,
+    validation_exception_handler,
+    http_exception_handler,
+    unhandled_exception_handler
+)
 from app.core import middleware
 from app.core.cors import setup_cors
 from app.routers import auth, category, level, course, instructor
@@ -34,6 +43,12 @@ app.include_router(level.router)
 app.include_router(course.router)
 app.include_router(instructor.router)
 app.include_router(evaluation.router)
+
+# Handlers de errors de requisições
+app.add_exception_handler(AppException, app_exception_handler)
+app.add_exception_handler(RequestValidationError, validation_exception_handler)
+app.add_exception_handler(HTTPException, http_exception_handler)
+app.add_exception_handler(Exception, unhandled_exception_handler)
 
 # Rota raiz
 @app.get("/")

--- a/backend/app/schemas/error.py
+++ b/backend/app/schemas/error.py
@@ -1,0 +1,6 @@
+from typing import Any
+from pydantic import BaseModel, Field
+
+class ErrorResponse(BaseModel):
+    data: Any = None
+    message: str = Field(..., examples=["Erro ao processar a requisição."])


### PR DESCRIPTION
## ✨ Padronização de Respostas de Erro da API

Esta PR introduz um **padrão único e consistente para respostas de erro** na aplicação, garantindo que todos os erros retornem o mesmo formato de payload, independentemente da origem.

### 🎯 Objetivo
Unificar o formato das respostas de erro da API para facilitar:
- o consumo pelo front-end (Axios),
- a leitura e depuração,
- a manutenção e evolução do código.
---
O padrão definido para erros é:

```json
{
  "data": {},
  "message": "Descrição clara do erro"
}
```
---
### O status code HTTP passa a ser a principal referência para o tipo de erro, enquanto:

- message descreve o erro de forma clara e customizável;
- data carrega os detalhes técnicos do erro (validação, contexto, payload, etc.).
---
### 🛠️ O que foi feito

- Criação de um schema padrão de erro (ErrorResponse) com data e message.
- Implementação de uma exceção base da aplicação (AppException) para controle centralizado de erros.

- Criação de exception handlers globais para:
  - erros de domínio (AppException);
  - erros de validação (RequestValidationError);
  - erros HTTP (HTTPException);
  - erros inesperados (fallback).
- Registro dos handlers no main.py, garantindo padronização automática.
- Refatoração de retornos manuais de erro para uso do novo padrão.
---
### ✅ Comportamento esperado

- Todas as respostas de erro seguem o mesmo formato { data, message }.
- O front-end pode utilizar diretamente:
  - response.status para lógica de fluxo;
  - response.data.message para feedback ao usuário;
  - response.data.data para detalhes do erro.
- Não há impacto em respostas de sucesso.
--- 
### 🔍 Observações

- A padronização não altera regras de negócio.
- Não há dependências externas adicionadas.
- A mudança é retrocompatível no nível de HTTP status codes.
---
### 🧪 Como validar

- Disparar erros de validação (422) e verificar o formato da resposta.
- Forçar erros de negócio (ex.: recurso não encontrado) e validar o payload.
- Verificar que erros inesperados retornam 500 no formato padrão.
---
### 🧾 Exemplo de erro retornado
```json
{
  "data": {
    "email": "teste@email.com"
  },
  "message": "Usuário não encontrado."
}
```